### PR TITLE
Avg posts per user per month

### DIFF
--- a/app/module/Statistics/src/Calculator/AveragePostsPerUserPerMonth.php
+++ b/app/module/Statistics/src/Calculator/AveragePostsPerUserPerMonth.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Statistics\Calculator;
+
+use SocialPost\Dto\SocialPostTo;
+use Statistics\Dto\StatisticsTo;
+
+/**
+ * Class AveragePostsPerUserPerMonth
+ *
+ * @package Statistics\Calculator
+ */
+class AveragePostsPerUserPerMonth extends AbstractCalculator
+{
+
+    protected const UNITS = 'posts';
+
+    protected const PRECISION = 2;
+    
+    /**
+     * @var array
+     */
+    private $totals = [];
+
+    /**
+     * @var array
+     */
+    private $users = [];
+
+    /**
+     * @param SocialPostTo $postTo
+     */
+    protected function doAccumulate(SocialPostTo $postTo): void
+    {
+        $key = $postTo->getDate()->format('\M\o\n\t\h m, Y');
+        if($postTo->getAuthorId() === null){
+            return;
+        }
+        if (!isset($this->users[$key][$postTo->getAuthorId()])){
+            $this->users[$key][$postTo->getAuthorId()]=true;
+        }
+        $this->totals[$key]=($this->totals[$key] ?? 0)+1;
+    }
+
+    /**
+     * @return StatisticsTo
+     */
+    protected function doCalculate(): StatisticsTo
+    {
+        $stats = new StatisticsTo();
+        foreach ($this->totals as $splitPeriod => $total) {
+            $child = (new StatisticsTo())
+                ->setName($this->parameters->getStatName())
+                ->setSplitPeriod($splitPeriod)
+                ->setValue(round($total/count($this->users[$splitPeriod]),self::PRECISION))
+                ->setUnits(self::UNITS);
+            $stats->addChild($child);
+        }
+
+        return $stats;
+    }
+}

--- a/app/module/Statistics/src/Calculator/Factory/StatisticsCalculatorFactory.php
+++ b/app/module/Statistics/src/Calculator/Factory/StatisticsCalculatorFactory.php
@@ -7,7 +7,7 @@ use Statistics\Calculator\AveragePostLength;
 use Statistics\Calculator\CalculatorComposite;
 use Statistics\Calculator\CalculatorInterface;
 use Statistics\Calculator\MaxPostLength;
-use Statistics\Calculator\NoopCalculator;
+use Statistics\Calculator\AveragePostsPerUserPerMonth;
 use Statistics\Calculator\TotalPostsPerWeek;
 use Statistics\Dto\ParamsTo;
 use Statistics\Enum\StatsEnum;
@@ -24,7 +24,7 @@ class StatisticsCalculatorFactory
         StatsEnum::AVERAGE_POST_LENGTH                     => AveragePostLength::class,
         StatsEnum::MAX_POST_LENGTH                         => MaxPostLength::class,
         StatsEnum::TOTAL_POSTS_PER_WEEK                    => TotalPostsPerWeek::class,
-        StatsEnum::AVERAGE_POSTS_NUMBER_PER_USER_PER_MONTH => NoopCalculator::class,
+        StatsEnum::AVERAGE_POSTS_NUMBER_PER_USER_PER_MONTH => AveragePostsPerUserPerMonth::class,
     ];
 
     /**

--- a/app/tests/data/social-posts-response-different-years.json
+++ b/app/tests/data/social-posts-response-different-years.json
@@ -1,0 +1,46 @@
+{
+    "meta": {
+        "response_end": {
+            "microtime": 1.53399078E9,
+            "time": "2018-08-11T12:33:51+00:00"
+        },
+        "response_time": 0
+    },
+    "data": {
+        "page": 1,
+        "posts": [
+            {
+                "id": "post5b6ed7aeeb572_d6a654ac",
+                "from_name": "Regenia Boice",
+                "from_id": "user_13",
+                "message": "belong epicalyx sound recruit hate kinship jealous baby pattern absent crew literature option indulge dirty permission parachute magnetic pit element graphic hell delay alcohol belief second message therapist detective triangle berry cage quote delete ally straw introduction wrist fixture smoke manage exact trail discourage village awful kit deprive line omission galaxy tribe velvet kitchen snow interference final horseshoe development culture introduction stable snow suffer mean fan unaware feminine approval housing depression candle crop body swipe railroad sanctuary feature water consumption water book lake pillow space complex",
+                "type": "status",
+                "created_time": "2018-08-11T06:38:54+00:00"
+            },
+            {
+                "id": "post5b6ed7aeeb613_37c3a760",
+                "from_name": "Isidro Schuett",
+                "from_id": "user_16",
+                "message": "mother drop falsify describe college area blue jean dressing fuss hell barrier export escape linen museum flat referee instal jurisdiction execute instrument part fuss waist helmet friend rhythm cord extend plagiarize thinker sister dominant basket dignity value dorm fill marsh angel publisher spend album reconcile charter convince bed quest housing failure landowner",
+                "type": "status",
+                "created_time": "2018-08-11T02:42:39+00:00"
+            },
+            {
+                "id": "post5b6ed7aeeb6cf_e16f82fb",
+                "from_name": "Lael Vassel",
+                "from_id": "user_0",
+                "message": "proud pool hilarious center bury facade button therapist opposite instal facade velvet full rough cover adoption grimace element fail herb dominant buy fling tie courtship empire chaos highway twist noble flourish clinic representative market magnetic album scheme harsh describe swim racism bother intermediate ankle rough ton discrimination instrument pit ban horror curl house script skin eject presidency nest correspondence viable offense money abbey size",
+                "type": "status",
+                "created_time": "2019-08-10T22:36:36+00:00"
+            },
+            {
+                "id": "post5b6ed7aeeb79b_131737df",
+                "from_name": "Lael Vassel",
+                "from_id": "user_0",
+                "message": "computer grandmother level body bed dismissal make viable dirty berry heavy bay lion quest house forget dead galaxy dramatic greeting design exact revoke era pit train thinker grandmother printer still leader act speech invisible achievement benefit shake golf address cause visual spend pavement elephant viable galaxy alcohol allocation birthday recruit freeze heal disaster chief leaflet hostile judgment mine delicate approval confine fuel crop depression syndrome use hostile Europe raid lighter passage press",
+                "type": "status",
+                "created_time": "2019-08-10T17:08:53+00:00"
+            }
+        ]
+    }
+}

--- a/app/tests/data/social-posts-response-empty.json
+++ b/app/tests/data/social-posts-response-empty.json
@@ -1,0 +1,14 @@
+{
+    "meta": {
+        "response_end": {
+            "microtime": 1.53399078E9,
+            "time": "2018-08-11T12:33:51+00:00"
+        },
+        "response_time": 0
+    },
+    "data": {
+        "page": 1,
+        "posts": [
+        ]
+    }
+}

--- a/app/tests/data/social-posts-response-no-user-id.json
+++ b/app/tests/data/social-posts-response-no-user-id.json
@@ -12,15 +12,13 @@
             {
                 "id": "post5b6ed7aeeb572_d6a654ac",
                 "from_name": "Regenia Boice",
-                "from_id": "user_13",
                 "message": "belong epicalyx sound recruit hate kinship jealous baby pattern absent crew literature option indulge dirty permission parachute magnetic pit element graphic hell delay alcohol belief second message therapist detective triangle berry cage quote delete ally straw introduction wrist fixture smoke manage exact trail discourage village awful kit deprive line omission galaxy tribe velvet kitchen snow interference final horseshoe development culture introduction stable snow suffer mean fan unaware feminine approval housing depression candle crop body swipe railroad sanctuary feature water consumption water book lake pillow space complex",
                 "type": "status",
-                "created_time": "2019-08-11T06:38:54+00:00"
+                "created_time": "2018-08-11T06:38:54+00:00"
             },
             {
                 "id": "post5b6ed7aeeb613_37c3a760",
                 "from_name": "Isidro Schuett",
-                "from_id": "user_16",
                 "message": "mother drop falsify describe college area blue jean dressing fuss hell barrier export escape linen museum flat referee instal jurisdiction execute instrument part fuss waist helmet friend rhythm cord extend plagiarize thinker sister dominant basket dignity value dorm fill marsh angel publisher spend album reconcile charter convince bed quest housing failure landowner",
                 "type": "status",
                 "created_time": "2019-08-11T02:42:39+00:00"
@@ -28,7 +26,6 @@
             {
                 "id": "post5b6ed7aeeb6cf_e16f82fb",
                 "from_name": "Lael Vassel",
-                "from_id": "user_0",
                 "message": "proud pool hilarious center bury facade button therapist opposite instal facade velvet full rough cover adoption grimace element fail herb dominant buy fling tie courtship empire chaos highway twist noble flourish clinic representative market magnetic album scheme harsh describe swim racism bother intermediate ankle rough ton discrimination instrument pit ban horror curl house script skin eject presidency nest correspondence viable offense money abbey size",
                 "type": "status",
                 "created_time": "2019-08-10T22:36:36+00:00"

--- a/app/tests/data/social-posts-response-precision.json
+++ b/app/tests/data/social-posts-response-precision.json
@@ -1,0 +1,46 @@
+{
+    "meta": {
+        "response_end": {
+            "microtime": 1.53399078E9,
+            "time": "2018-08-11T12:33:51+00:00"
+        },
+        "response_time": 0
+    },
+    "data": {
+        "page": 1,
+        "posts": [
+            {
+                "id": "post5b6ed7aeeb572_d6a654ac",
+                "from_name": "Regenia Boice",
+                "from_id": "user_13",
+                "message": "belong epicalyx sound recruit hate kinship jealous baby pattern absent crew literature option indulge dirty permission parachute magnetic pit element graphic hell delay alcohol belief second message therapist detective triangle berry cage quote delete ally straw introduction wrist fixture smoke manage exact trail discourage village awful kit deprive line omission galaxy tribe velvet kitchen snow interference final horseshoe development culture introduction stable snow suffer mean fan unaware feminine approval housing depression candle crop body swipe railroad sanctuary feature water consumption water book lake pillow space complex",
+                "type": "status",
+                "created_time": "2018-08-11T06:38:54+00:00"
+            },
+            {
+                "id": "post5b6ed7aeeb613_37c3a760",
+                "from_name": "Isidro Schuett",
+                "from_id": "user_16",
+                "message": "mother drop falsify describe college area blue jean dressing fuss hell barrier export escape linen museum flat referee instal jurisdiction execute instrument part fuss waist helmet friend rhythm cord extend plagiarize thinker sister dominant basket dignity value dorm fill marsh angel publisher spend album reconcile charter convince bed quest housing failure landowner",
+                "type": "status",
+                "created_time": "2019-08-11T02:42:39+00:00"
+            },
+            {
+                "id": "post5b6ed7aeeb6cf_e16f82fb",
+                "from_name": "Lael Vassel",
+                "from_id": "user_0",
+                "message": "proud pool hilarious center bury facade button therapist opposite instal facade velvet full rough cover adoption grimace element fail herb dominant buy fling tie courtship empire chaos highway twist noble flourish clinic representative market magnetic album scheme harsh describe swim racism bother intermediate ankle rough ton discrimination instrument pit ban horror curl house script skin eject presidency nest correspondence viable offense money abbey size",
+                "type": "status",
+                "created_time": "2019-08-10T22:36:36+00:00"
+            },
+            {
+                "id": "post5b6ed7aeeb79b_131737df",
+                "from_name": "Lael Vassel",
+                "from_id": "user_0",
+                "message": "computer grandmother level body bed dismissal make viable dirty berry heavy bay lion quest house forget dead galaxy dramatic greeting design exact revoke era pit train thinker grandmother printer still leader act speech invisible achievement benefit shake golf address cause visual spend pavement elephant viable galaxy alcohol allocation birthday recruit freeze heal disaster chief leaflet hostile judgment mine delicate approval confine fuel crop depression syndrome use hostile Europe raid lighter passage press",
+                "type": "status",
+                "created_time": "2019-08-10T17:08:53+00:00"
+            }
+        ]
+    }
+}

--- a/app/tests/unit/AveragePostsPerUserPerMonthTest.php
+++ b/app/tests/unit/AveragePostsPerUserPerMonthTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Tests\unit;
+
+use DateTime;
+use PHPUnit\Framework\TestCase;
+use SocialPost\Hydrator\FictionalPostHydrator;
+use Statistics\Calculator\AveragePostsPerUserPerMonth;
+use Statistics\Dto\ParamsTo;
+use Statistics\Dto\StatisticsTo;
+
+use function PHPUnit\Framework\assertEmpty;
+use function PHPUnit\Framework\assertEquals;
+
+/**
+ * Class AveragePostsPerUserPerMonthTest
+ *
+ * @package Tests\unit
+ */
+class AveragePostsPerUserPerMonthTest extends TestCase
+{
+    public function testDefault(): void
+    {
+        $data = $this->prepareData('/srv/sm_assignment/tests/data/social-posts-response.json', new DateTime('2018-01-01'), new DateTime('2022-01-01'));
+        $value = $data->getChildren()[0];
+        assertEquals(1,$value->getValue());
+    }
+    public function testWrongDates(): void
+    {
+        $data = $this->prepareData('/srv/sm_assignment/tests/data/social-posts-response.json', new DateTime('2022-01-01'), new DateTime('2022-01-01'));
+        assertEmpty($data->getChildren());
+    }
+    public function testDifferentYears():void
+    {
+        $data = $this->prepareData('/srv/sm_assignment/tests/data/social-posts-response-different-years.json', new DateTime('2018-01-01'), new DateTime('2022-01-01'));
+        assertEquals(1, $data->getChildren()[0]->getValue());
+        assertEquals(2, $data->getChildren()[1]->getValue());               
+    }
+    public function testPrecision(): void
+    {
+        $data = $this->prepareData('/srv/sm_assignment/tests/data/social-posts-response-precision.json', new DateTime('2018-01-01'), new DateTime('2022-01-01'));
+        assertEquals(1, $data->getChildren()[0]->getValue());
+        assertEquals(1.5, $data->getChildren()[1]->getValue());
+    }
+    public function testNoData(): void
+    {
+        $data = $this->prepareData('/srv/sm_assignment/tests/data/social-posts-response-empty.json', new DateTime('2018-01-01'), new DateTime('2022-01-01'));
+        assertEmpty($data->getChildren());
+    }
+    /**
+     * Gets data from file and processes
+     * 
+     * @param string    $path Path to input file with test data
+     * @param DateTime  $from Start date in params 
+     * @param DateTime  $to End date in params
+     * @return StatisticsTo 
+     */
+    public function prepareData(string $path, DateTime $from, DateTime $to):StatisticsTo
+    {
+        $replyRaw = json_decode(file_get_contents($path), true);
+        $hydrator = new FictionalPostHydrator();
+        $testClass = new AveragePostsPerUserPerMonth();
+        $paramsTo = new ParamsTo();
+        $paramsTo->setStartDate($from);
+        $paramsTo->setEndDate($to);
+        $paramsTo->setStatName('test');
+        $testClass->setParameters($paramsTo);
+        foreach ($replyRaw['data']['posts'] as $value) {
+            $testClass->accumulateData($hydrator->hydrate($value));
+        }
+        return $testClass->calculate();    
+    }
+}

--- a/app/tests/unit/AveragePostsPerUserPerMonthTest.php
+++ b/app/tests/unit/AveragePostsPerUserPerMonthTest.php
@@ -21,33 +21,56 @@ use function PHPUnit\Framework\assertEquals;
  */
 class AveragePostsPerUserPerMonthTest extends TestCase
 {
+    /**
+     * Check if works
+     */
     public function testDefault(): void
     {
         $data = $this->prepareData('/srv/sm_assignment/tests/data/social-posts-response.json', new DateTime('2018-01-01'), new DateTime('2022-01-01'));
         $value = $data->getChildren()[0];
         assertEquals(1,$value->getValue());
     }
+    /**
+     * Check if dates in params is used to filter data
+     */
     public function testWrongDates(): void
     {
         $data = $this->prepareData('/srv/sm_assignment/tests/data/social-posts-response.json', new DateTime('2022-01-01'), new DateTime('2022-01-01'));
         assertEmpty($data->getChildren());
     }
+    /**
+     * Check same month in different years
+     */
     public function testDifferentYears():void
     {
         $data = $this->prepareData('/srv/sm_assignment/tests/data/social-posts-response-different-years.json', new DateTime('2018-01-01'), new DateTime('2022-01-01'));
         assertEquals(1, $data->getChildren()[0]->getValue());
         assertEquals(2, $data->getChildren()[1]->getValue());               
     }
+    /**
+     * Check precision and rounding
+     */
     public function testPrecision(): void
     {
         $data = $this->prepareData('/srv/sm_assignment/tests/data/social-posts-response-precision.json', new DateTime('2018-01-01'), new DateTime('2022-01-01'));
-        assertEquals(1, $data->getChildren()[0]->getValue());
-        assertEquals(1.5, $data->getChildren()[1]->getValue());
+        assertEquals(1.33, $data->getChildren()[0]->getValue());
     }
+    /**
+     * Empty data- empty statistics
+     */
     public function testNoData(): void
     {
         $data = $this->prepareData('/srv/sm_assignment/tests/data/social-posts-response-empty.json', new DateTime('2018-01-01'), new DateTime('2022-01-01'));
         assertEmpty($data->getChildren());
+    }
+    /**
+     * If some posts don't have user id - they won't count
+     */
+    public function testNoUserId(): void
+    {
+        $data = $this->prepareData('/srv/sm_assignment/tests/data/social-posts-response-no-user-id.json', new DateTime('2018-01-01'), new DateTime('2022-01-01'));
+        assertEquals(1, $data->getChildren()[0]->getValue());
+       
     }
     /**
      * Gets data from file and processes


### PR DESCRIPTION
For the slide desk, there is no need to show all the users that wrote a post in a given period of time, it can be millions of people, so I think that it will be more informative to show for every month average number of posts written by users. 
But there is a caveat here, it's not an average number of posts per user per month, it's the average number of posts per user per month of **active** users, or users that wrote at least one post in each month. I could accumulate all users from given period, but it won't be useful for big picture. 